### PR TITLE
Legends overlap with ToolTip

### DIFF
--- a/superset/assets/visualizations/nvd3_vis.js
+++ b/superset/assets/visualizations/nvd3_vis.js
@@ -314,6 +314,7 @@ function nvd3Vis(slice, payload) {
         chart.showLegend(false);
       } else {
         chart.showLegend(fd.show_legend);
+        chart.legend.margin({top: 5, right:30, left:80, bottom: 30}); // you can add your own margins . 
       }
     }
 


### PR DESCRIPTION
In the time series bar chart the Tooltip gets overlapped with the legends . I have added the Margin property to the legend . This property gets applied to all the charts when the legend option is ticked .